### PR TITLE
Fixed gi database query quoting

### DIFF
--- a/taxonomy_lookup_embedded.pl
+++ b/taxonomy_lookup_embedded.pl
@@ -115,7 +115,7 @@ $gi = $ARGV[0];
 $lineage = "";
 chomp $gi;
 # convert gi -> taxid
-my $ary = $db->selectrow_arrayref("SELECT taxid FROM gi_taxid WHERE gi = $gi LIMIT 1");
+my $ary = $db->selectrow_arrayref("SELECT taxid FROM gi_taxid WHERE gi = \"$gi\" LIMIT 1");
 if ($ary){
 	$taxid = trim($ary->[0]);
 }


### PR DESCRIPTION
This fixes the handling of a list of gi's where an incorrect query (such as a string) returns nothing instead of crashing.